### PR TITLE
Implement async queries

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 // TODO Don't hardcode this
-const version = "v0.1.0"
+const version = "v0.0.1"
 
 func main() {
 
@@ -33,7 +33,7 @@ func main() {
 	if *debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
-	// TODO Sanity check we can connect here and verify promtheus server has correct config
+	// TODO Sanity check we can connect here and verify prometheus server has correct config
 
 	client, err := api.NewClient(api.Config{
 		Address: *apiAddr,

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -32,5 +32,5 @@ type edgesMetrics struct {
 }
 
 func (e edgesMetrics) SummaryHandler() http.Handler {
-	return srv.HandleEdges(e.API)
+	return srv.HandleSummary(e.API)
 }

--- a/srv/api_handlers.go
+++ b/srv/api_handlers.go
@@ -127,20 +127,22 @@ type EdgeResp struct {
 type AppVersionNamespace string
 
 type Node struct {
-	App       string             `json:"app"`
-	Version   string             `json:"version"`
-	Namespace string             `json:"namespace"`
-	Stats     map[string]float64 `json:"stats"`
+	App       string `json:"app"`
+	Version   string `json:"version"`
+	Namespace string `json:"namespace"`
+	// use float64 to avoid custom types unmarshalling from prometheus
+	Stats map[string]float64 `json:"stats"`
 }
 
 type Edge struct {
-	FromNamespace string             `json:"fromNamespace"`
-	FromApp       string             `json:"fromApp"`
-	FromVersion   string             `json:"fromVersion"`
-	ToNamespace   string             `json:"toNamespace"`
-	ToApp         string             `json:"toApp"`
-	ToVersion     string             `json:"toVersion"`
-	Stats         map[string]float64 `json:"stats"`
+	FromNamespace string `json:"fromNamespace"`
+	FromApp       string `json:"fromApp"`
+	FromVersion   string `json:"fromVersion"`
+	ToNamespace   string `json:"toNamespace"`
+	ToApp         string `json:"toApp"`
+	ToVersion     string `json:"toVersion"`
+	// use float64 to avoid custom types unmarshalling from prometheus
+	Stats map[string]float64 `json:"stats"`
 }
 
 func (h *handler) handleAPIEdges() http.Handler {
@@ -240,6 +242,10 @@ func HandleSummary(api v1.API) http.Handler {
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 
+		ch := make(chan StatResp, 2)
+		go asyncStatQuery(ctx, promAPI, directionInbound, windowDefault, ch)
+		go asyncStatQuery(ctx, promAPI, directionOutbound, windowDefault, ch)
+
 		incomingResp, warn, err := promAPI.Query(ctx, IncomingIdentityQuery, time.Now())
 
 		if warn != nil {
@@ -274,37 +280,65 @@ func HandleSummary(api v1.API) http.Handler {
 		}
 
 		//TODO use ErrGroup here
-		EdgeList, err := processEdgeMetrics(ctx, promAPI, incomingResp.(model.Vector), outgoingResp.(model.Vector), "")
+		EdgeList, err := asyncProcessEdges(ctx, promAPI, incomingResp.(model.Vector), outgoingResp.(model.Vector), "")
 		if err != nil {
 			logrus.Errorf("%v", err)
 			renderJSONError(w, err, http.StatusInternalServerError)
 			return
 		}
-		logrus.Infof("%+v", EdgeList)
+		logrus.Debugf("%+v", EdgeList)
 
 		// create Nodes based upon all seen apps
 		NodeList := buildNodeList(EdgeList, "")
 
-		for i := range NodeList {
-			NodeList[i].Stats, err = statQuery(ctx, promAPI, NodeList[i].App, NodeList[i].Version, windowDefault, "inbound")
-			if err != nil {
-				err = fmt.Errorf("unable to populate node list: %v", err)
-				logrus.Errorf("%v", err)
-				renderJSONError(w, err, http.StatusInternalServerError)
-				return
-			}
-		}
+		//for i := range NodeList {
+		//	NodeList[i].Stats, err = statQuery(ctx, promAPI, NodeList[i].App, NodeList[i].Version, windowDefault, "inbound")
+		//	if err != nil {
+		//		err = fmt.Errorf("unable to populate node list: %v", err)
+		//		logrus.Errorf("%v", err)
+		//		renderJSONError(w, err, http.StatusInternalServerError)
+		//		return
+		//	}
+		//}
 
+		// no stats have been inserted yet
 		resp := EdgeResp{
 			Nodes:     NodeList,
 			Edges:     EdgeList,
-			Integrity: "full",
+			Integrity: "partial",
 		}
+		var nodes []Node
+		var edges []Edge
+		for i := 0; i < 2; i++ {
+			statResp := <-ch
+			if statResp.err != nil {
+				//TODO provide support for partial queries w/o stats
+				renderJSONError(w, statResp.err, http.StatusInternalServerError)
+				return
+			}
+			if statResp.direction == directionInbound {
+				nodes, err = processInboundStats(resp.Nodes, statResp.result)
+				if err != nil {
+					renderJSONError(w, err, http.StatusInternalServerError)
+					return
+				}
+			}
+			if statResp.direction == directionOutbound {
+				edges, err = processOutboundStats(resp.Edges, statResp.result)
+				if err != nil {
+					renderJSONError(w, err, http.StatusInternalServerError)
+					return
+				}
+			}
+		}
+
+		resp = EdgeResp{Nodes: nodes, Edges: edges, Integrity: "full"}
 		renderJSON(w, resp)
 	})
 }
 
-// buildNodeList creates a node list from slice of edges, optionally creating a nodelist if targetNamesace is not ""
+// buildNodeList creates a node list from slice of edges, optionally creating a nodelist from a single namespace
+// if targetNamesace is not ""
 func buildNodeList(edgeList []Edge, targetNamespace string) []Node {
 	NodeList := make([]Node, 0, len(edgeList))
 	appSet := make(map[AppVersionNamespace]bool, len(edgeList))

--- a/srv/api_handlers.go
+++ b/srv/api_handlers.go
@@ -221,7 +221,7 @@ func HandleEdges(api v1.API) http.Handler {
 			Edges:     EdgeList,
 			Integrity: "full",
 		}
-		err = checkNan(resp)
+		err = checkNanBlock(resp)
 		if err != nil {
 			renderJSONError(w, err, http.StatusInternalServerError)
 		}

--- a/srv/api_handlers.go
+++ b/srv/api_handlers.go
@@ -291,16 +291,6 @@ func HandleSummary(api v1.API) http.Handler {
 		// create Nodes based upon all seen apps
 		NodeList := buildNodeList(EdgeList, "")
 
-		//for i := range NodeList {
-		//	NodeList[i].Stats, err = statQuery(ctx, promAPI, NodeList[i].App, NodeList[i].Version, windowDefault, "inbound")
-		//	if err != nil {
-		//		err = fmt.Errorf("unable to populate node list: %v", err)
-		//		logrus.Errorf("%v", err)
-		//		renderJSONError(w, err, http.StatusInternalServerError)
-		//		return
-		//	}
-		//}
-
 		// no stats have been inserted yet
 		resp := EdgeResp{
 			Nodes:     NodeList,

--- a/srv/const.go
+++ b/srv/const.go
@@ -1,7 +1,10 @@
 package srv
 
 const (
-	windowDefault          = "30s"
+	windowDefault     = "30s"
+	directionInbound  = "inbound"
+	directionOutbound = "outbound"
+
 	clusterMemoryUsage     = `sum (container_memory_working_set_bytes{id="/"}) / sum (machine_memory_bytes{}) * 100`
 	clusterCPUUsage1MinAvg = `sum (rate (container_cpu_usage_seconds_total{id="/",}[1m])) / sum (machine_cpu_cores) * 100`
 	clusterFilesytemUse    = `sum (container_fs_usage_bytes{device=~"^/dev/[sv]d[a-z][1-9]$",id="/"}) / sum (container_fs_limit_bytes{device=~"^/dev/[sv]d[a-z][1-9]$",id="/",}) * 100`
@@ -13,9 +16,11 @@ const (
 	promLatencyP50 = "0.5"
 	promLatencyP95 = "0.95"
 	promLatencyP99 = "0.99"
+	RPS            = `sum(irate(request_total%s[%s])) by (app,version,namespace)`
+	SUCCESSRATE    = `sum(irate(response_total%s[%s])) by (app,version,namespace) / sum(irate(response_total%s[%s])) by (app,version,namespace)`
 
-	RPS         = `sum(irate(request_total%s[%s])) by (app)`
-	SUCCESSRATE = `sum(irate(response_total%s[%s])) by (app) / sum(irate(response_total%s[%s])) by (app)`
+	rps         = "rps"
+	successRate = "successRate"
 
 	DEBUG2 = `sum(irate(response_total{classification="success",  direction="inbound"}[30s])) by (app) / sum(irate(response_total{ direction="inbound"}[30s])) by (app)`
 	DEBUG3 = `histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{direction="inbound"}[30s])) by (le,app))`

--- a/srv/edges.go
+++ b/srv/edges.go
@@ -84,7 +84,6 @@ func processEdgeMetrics(ctx context.Context, promAPI v1.API, inbound, outbound m
 				ToApp:         string(dst[model.LabelName("app")]),
 				ToVersion:     string(dst[model.LabelName("version")]),
 			}
-
 			stats, err := statQuery(ctx, promAPI, edge.FromApp, edge.FromVersion, windowDefault, "outbound")
 			if err != nil {
 				return nil, err
@@ -94,5 +93,85 @@ func processEdgeMetrics(ctx context.Context, promAPI v1.API, inbound, outbound m
 		}
 	}
 
+	return edges, nil
+}
+
+// async Process edges does the same as processEdges but does not perform any stats queries itself
+func asyncProcessEdges(ctx context.Context, promAPI v1.API, inbound, outbound model.Vector, selectedNamespace string) ([]Edge, error) {
+	var edges []Edge
+	dstIndex := map[model.LabelValue]model.Metric{}
+	srcIndex := map[model.LabelValue][]model.Metric{}
+	resourceType := "deployment"
+	resourceReplacementInbound := resourceType
+	resourceReplacementOutbound := "dst_" + resourceType
+
+	for _, sample := range inbound {
+		// skip inbound results without a clientID because we cannot construct edge
+		// information
+		clientID, ok := sample.Metric[model.LabelName("client_id")]
+		if ok {
+			dstResource := string(sample.Metric[model.LabelName(resourceReplacementInbound)])
+
+			// format of clientId is id.namespace.serviceaccount.cluster.local
+			clientIDSlice := strings.Split(string(clientID), ".")
+			srcNs := clientIDSlice[1]
+			key := model.LabelValue(fmt.Sprintf("%s.%s", dstResource, srcNs))
+			dstIndex[key] = sample.Metric
+		} else {
+			logrus.Debugf("dropped metric: %s", sample.Metric)
+		}
+	}
+
+	for _, sample := range outbound {
+		dstResource := sample.Metric[model.LabelName(resourceReplacementOutbound)]
+		srcNs := sample.Metric[model.LabelName("namespace")]
+
+		key := model.LabelValue(fmt.Sprintf("%s.%s", dstResource, srcNs))
+		if _, ok := srcIndex[key]; !ok {
+			srcIndex[key] = []model.Metric{}
+		}
+		srcIndex[key] = append(srcIndex[key], sample.Metric)
+	}
+
+	for key, sources := range srcIndex {
+		for _, src := range sources {
+			srcNamespace := string(src[model.LabelName("namespace")])
+
+			dst, ok := dstIndex[key]
+
+			// if no destination, attempt to build from source data
+			if !ok {
+				dstNamespace := string(src[model.LabelName("dst_namespace")])
+
+				// skip if selected namespace is given and neither the source nor
+				// destination is in the selected namespace
+				if selectedNamespace != "" && srcNamespace != selectedNamespace &&
+					dstNamespace != selectedNamespace {
+					continue
+				}
+			}
+
+			dstNamespace := string(dst[model.LabelName("namespace")])
+
+			// skip if selected namespace is given and neither the source nor
+			// destination is in the selected namespace
+			if selectedNamespace != "" && srcNamespace != selectedNamespace &&
+				dstNamespace != selectedNamespace {
+				continue
+			}
+			//TODO if fromApp would be empty we should also skip it
+
+			edge := Edge{
+				FromNamespace: srcNamespace,
+				FromApp:       string(src[model.LabelName("app")]),
+				FromVersion:   string(src[model.LabelName("version")]),
+				ToNamespace:   dstNamespace,
+				ToApp:         string(dst[model.LabelName("app")]),
+				ToVersion:     string(dst[model.LabelName("version")]),
+			}
+			edges = append(edges, edge)
+		}
+	}
+	// no stats
 	return edges, nil
 }

--- a/srv/server.go
+++ b/srv/server.go
@@ -121,6 +121,7 @@ func NewServer(
 	server.router.Handle("/api/version", handler.handleAPIVersion())
 	server.router.Handle("/api/v0/cluster", handler.handleClusterInfo())
 	//server.router.GET("/api/v0/app/:app", handler.handleAppStats)
+	server.router.Handle("/api/v0/namespace", handler.handleAPIEdges())
 	server.router.Handle("/api/v0/namespace/{namespace}", handler.handleAPIEdges())
 	server.router.Handle("/api/v0/summary", handler.SummaryHandler())
 

--- a/srv/stats.go
+++ b/srv/stats.go
@@ -3,10 +3,10 @@ package srv
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
-
 	"github.com/prometheus/common/model"
 	"github.com/sirupsen/logrus"
 )
@@ -20,7 +20,10 @@ type promResult struct {
 var quantiles = [3]string{promLatencyP50, promLatencyP95, promLatencyP99}
 
 func statQuery(ctx context.Context, promAPI v1.API, appName, version, window, direction string) (map[string]float64, error) {
-	resultChan := make(chan promResult)
+	if window == "" {
+		window = windowDefault
+	}
+	resultChan := make(chan promResult, len(quantiles))
 	var queryLabels string
 	if version != "" {
 		queryLabels = fmt.Sprintf("{direction=\"%s\",app=\"%s\",version=\"%s\"}", direction, appName, version)
@@ -43,7 +46,6 @@ func statQuery(ctx context.Context, promAPI v1.API, appName, version, window, di
 			}
 			if latencyResult.Type() != model.ValVector {
 				err := fmt.Errorf("unexpected query result type (expected Vector): %s", latencyResult.Type())
-				logrus.Errorf("%v", err)
 				resultChan <- promResult{
 					prom: "",
 					vec:  nil,
@@ -142,4 +144,196 @@ func statQuery(ctx context.Context, promAPI v1.API, appName, version, window, di
 		resp["successRate"] = float64(resultScalar[0].Value)
 	}
 	return resp, nil
+}
+
+const appVersionDeployment = "app,version,deployment"
+
+type StatResp struct {
+	direction string
+	result    map[string]model.Vector
+	err       error
+}
+
+func asyncStatQuery(ctx context.Context, promAPI v1.API, direction, window string, c chan StatResp) {
+	if window == "" {
+		window = windowDefault
+	}
+	statresp := StatResp{
+		direction: direction,
+		result:    nil,
+		err:       nil}
+
+	resultChan := make(chan promResult, len(quantiles))
+	queryLabels := fmt.Sprintf("{direction=\"%s\"}", direction)
+
+	for _, quantile := range quantiles {
+		go func(quantile string) {
+			latencyQuery := fmt.Sprintf(latencyQuantileQuery, quantile, queryLabels, window, appVersionDeployment)
+			logrus.Debugf("Performing stat query: %v", latencyQuery)
+			latencyResult, warnings, err := promAPI.Query(ctx, latencyQuery, time.Now())
+			if err != nil {
+				resultChan <- promResult{
+					prom: "",
+					vec:  nil,
+					err:  err,
+				}
+				return
+			}
+			if latencyResult.Type() != model.ValVector {
+				err := fmt.Errorf("unexpected query result type (expected Vector): %s", latencyResult.Type())
+				resultChan <- promResult{
+					prom: "",
+					vec:  nil,
+					err:  err,
+				}
+				return
+			}
+			if warnings != nil {
+				logrus.Warnf("%v", warnings)
+			}
+
+			resultChan <- promResult{
+				prom: quantile,
+				vec:  latencyResult.(model.Vector),
+				err:  err,
+			}
+		}(quantile)
+	}
+
+	resp := make(map[string]model.Vector)
+	var err error
+	for i := 0; i < len(quantiles); i++ {
+		result := <-resultChan
+		if result.err != nil {
+			logrus.Errorf("query failed with %s", result.err)
+			err = result.err
+		} else {
+			var label string
+			switch result.prom {
+			case promLatencyP50:
+				label = "p50ms"
+			case promLatencyP95:
+				label = "p90ms"
+			case promLatencyP99:
+				label = "p99ms"
+			default:
+				label = result.prom
+			}
+			if len(result.vec) == 0 {
+				resp[label] = nil
+			} else {
+				resp[label] = result.vec
+			}
+		}
+	}
+	if err != nil {
+		// only return if all queries succeeded?
+		statresp.err = err
+		c <- statresp
+		return
+	}
+
+	rpsQuery := fmt.Sprintf(RPS, queryLabels, window)
+	logrus.Debugf("Performing rps query: %v", rpsQuery)
+	result, warnings, err := promAPI.Query(ctx, rpsQuery, time.Now())
+	if err != nil {
+		c <- StatResp{}
+	}
+	if len(warnings) > 0 {
+		logrus.Warnf("%v", warnings)
+	}
+	resultVector, ok := result.(model.Vector)
+	if !ok {
+		statresp.err = fmt.Errorf("unexpected query result type (expected Vector): %s", result.Type())
+		c <- statresp
+		return
+	}
+	if len(resultVector) == 0 {
+		resp["rps"] = nil
+	} else {
+		resp["rps"] = resultVector
+	}
+
+	var nonSuccesRateLabels string
+
+	queryLabels = fmt.Sprintf("{classification=\"success\",direction=\"%s\"}", direction)
+	nonSuccesRateLabels = fmt.Sprintf("{direction=\"%s\"}", direction)
+
+	successRateQuery := fmt.Sprintf(SUCCESSRATE, queryLabels, window, nonSuccesRateLabels, window)
+	logrus.Debugf("Performing success rate query: %v", successRateQuery)
+	result, warnings, err = promAPI.Query(ctx, successRateQuery, time.Now())
+	if err != nil {
+		statresp.err = err
+		c <- statresp
+		return
+	}
+	if len(warnings) > 0 {
+		logrus.Warnf("%v", warnings)
+	}
+	resultVector, ok = result.(model.Vector)
+	if !ok {
+		statresp.err = fmt.Errorf("unexpected query result type (expected Vector): %s", result.Type())
+		c <- statresp
+		return
+	}
+	if len(resultVector) == 0 {
+		resp["successRate"] = nil
+	} else {
+		resp["successRate"] = resultVector
+	}
+	statresp.result = resp
+	c <- statresp
+	return
+}
+
+// processInboundStats handles building the stats information for edges and nodes
+func processInboundStats(nodes []Node, stats map[string]model.Vector) ([]Node, error) {
+
+	for j := range nodes {
+		metrics := getMetrics(nodes[j].App, nodes[j].Version, stats)
+		nodes[j].Stats = metrics
+	}
+	return nodes, nil
+}
+
+func processOutboundStats(edges []Edge, stats map[string]model.Vector) ([]Edge, error) {
+
+	for i := range edges {
+		metrics := getMetrics(edges[i].FromApp, edges[i].FromVersion, stats)
+		edges[i].Stats = metrics
+	}
+	return edges, nil
+}
+
+func getMetrics(app, version string, stats map[string]model.Vector) map[string]float64 {
+	//TODO use const here
+	metrics := [5]string{"p50ms", "p90ms", "p99ms", rps, successRate}
+
+	result := map[string]float64{}
+	//var wg sync.WaitGroup
+	sema := sync.Mutex{}
+	for _, metric := range metrics {
+		samples := stats[metric]
+		//wg.Add(1)
+		//go func(samples model.Vector, metric string, sema *sync.Mutex, wg *sync.WaitGroup) {
+		for _, sample := range samples {
+			appVar, ok := sample.Metric["app"]
+			if !ok || string(appVar) != app {
+				continue
+			}
+			verVar, ok := sample.Metric["version"]
+			if !ok || string(verVar) != version {
+				continue
+			}
+			logrus.Debugf("found %s for app: %s version: %s", metric, app, version)
+			sema.Lock()
+			result[metric] = float64(sample.Value)
+			sema.Unlock()
+			//wg.Done()
+		}
+		//}(samples, metric, &sema, &wg)
+
+	}
+	//wg.Wait()
+	return result
 }

--- a/srv/util.go
+++ b/srv/util.go
@@ -7,7 +7,7 @@ import (
 
 // TODO: check earlier in the code if we find a NaN
 // 	so that we debug the query
-func checkNan(block EdgeResp) error {
+func checkNanBlock(block EdgeResp) error {
 
 	for _, node := range block.Nodes {
 		for key, value := range node.Stats {


### PR DESCRIPTION
The new summary handler can now make queries in constant time instead
of making another set of stat queries for every node seen on a set of
edges.

Also adds a /namespace handler to query all namespaces with the previous
method to test for regressions.