### PR TITLE
Ensure stats are never empty

### DIFF
--- a/srv/stats.go
+++ b/srv/stats.go
@@ -329,7 +329,9 @@ func getMetrics(app, version string, stats map[string]model.Vector) map[string]f
 			}
 			result[metric] = float64(sample.Value)
 		}
-
+		if _, ok := result[metric]; !ok {
+			result[metric] = 0.0
+		}
 	}
 	return result
 }


### PR DESCRIPTION
One diference in the JSON returns of async and sync
queries are the lack of stats in the async queries due not being
able to identify the app and version from the stats response.